### PR TITLE
Extention ir enum

### DIFF
--- a/KNOTS/Components/Pages/Login.razor
+++ b/KNOTS/Components/Pages/Login.razor
@@ -86,3 +86,4 @@
         statusMessage = "You have logged out.";
     }
 }
+

--- a/KNOTS/Services/GameRoomExs.cs
+++ b/KNOTS/Services/GameRoomExs.cs
@@ -6,7 +6,7 @@ public static class GameRoomExs
 {
 
     public static bool isFull(this GameRoom room) {return room.Players.Count >= room.MaxPlayers;}
-    public static bool hasStarted(this GameRoom room) {return room.IsGameStarted;}
+    public static bool hasStarted(this GameRoom room) {return room.State == gameState.inProgress;}
     public static bool hasPlayer(this GameRoom room, string username) {return room.Players.Any(x => x.Username == username);}
 
 
@@ -20,6 +20,7 @@ public static class GameRoomExs
 
         if (room.hasPlayer(username))
             return new JoinRoomResult { Success = false, Message = "Username is already taken" };
+        
 
         return new JoinRoomResult { Success = true };
     }

--- a/KNOTS/Services/GameRoomExs.cs
+++ b/KNOTS/Services/GameRoomExs.cs
@@ -4,34 +4,22 @@ namespace KNOTS.Services;
 //cia yra testai, kuriuos passinus galima prisijungti i kambari
 public static class GameRoomExs
 {
+
+    public static bool isFull(this GameRoom room) {return room.Players.Count >= room.MaxPlayers;}
+    public static bool hasStarted(this GameRoom room) {return room.IsGameStarted;}
+    public static bool hasPlayer(this GameRoom room, string username) {return room.Players.Any(x => x.Username == username);}
+
+
     public static JoinRoomResult CanJoin(this GameRoom room, string username)
     {
-        if (room.Players.Count >= room.MaxPlayers)
-        {
-            return new JoinRoomResult 
-            { 
-                Success = false, 
-                Message = "Room is full" 
-            };
-        }
+        if (room.isFull())
+            return new JoinRoomResult { Success = false, Message = "Room is full" };
 
-        if (room.IsGameStarted)
-        {
-            return new JoinRoomResult
-            {
-                Success = false,
-                Message = "Game has already started"
-            };
-        }
+        if (room.hasStarted())
+            return new JoinRoomResult { Success = false, Message = "Game has already started" };
 
-        if (room.Players.Any(x => x.Username == username))
-        {
-            return new JoinRoomResult
-            {
-                Success = false,
-                Message = "Username is already taken"
-            };
-        }
+        if (room.hasPlayer(username))
+            return new JoinRoomResult { Success = false, Message = "Username is already taken" };
 
         return new JoinRoomResult { Success = true };
     }

--- a/KNOTS/Services/GameRoomExs.cs
+++ b/KNOTS/Services/GameRoomExs.cs
@@ -1,0 +1,39 @@
+namespace KNOTS.Services;
+
+//joingameroom funkcijos extensionas, skirtas papildyti funkcionaluma funkcijos skirtos prisijungti i kambari
+//cia yra testai, kuriuos passinus galima prisijungti i kambari
+public static class GameRoomExs
+{
+    public static JoinRoomResult CanJoin(this GameRoom room, string username)
+    {
+        if (room.Players.Count >= room.MaxPlayers)
+        {
+            return new JoinRoomResult 
+            { 
+                Success = false, 
+                Message = "Room is full" 
+            };
+        }
+
+        if (room.IsGameStarted)
+        {
+            return new JoinRoomResult
+            {
+                Success = false,
+                Message = "Game has already started"
+            };
+        }
+
+        if (room.Players.Any(x => x.Username == username))
+        {
+            return new JoinRoomResult
+            {
+                Success = false,
+                Message = "Username is already taken"
+            };
+        }
+
+        return new JoinRoomResult { Success = true };
+    }
+    
+}

--- a/KNOTS/Services/GameRoomExs.cs
+++ b/KNOTS/Services/GameRoomExs.cs
@@ -6,23 +6,19 @@ public static class GameRoomExs
 {
 
     public static bool isFull(this GameRoom room) {return room.Players.Count >= room.MaxPlayers;}
-    public static bool hasStarted(this GameRoom room) {return room.State == gameState.inProgress;}
+    public static bool hasStarted(this GameRoom room) {return room.State == GameState.inProgress;}
     public static bool hasPlayer(this GameRoom room, string username) {return room.Players.Any(x => x.Username == username);}
 
 
     public static JoinRoomResult CanJoin(this GameRoom room, string username)
     {
-        if (room.isFull())
-            return new JoinRoomResult { Success = false, Message = "Room is full" };
+        if (room.isFull()) return new JoinRoomResult { Success = false, Message = "Room is full", State = GameState.inProgress};
 
-        if (room.hasStarted())
-            return new JoinRoomResult { Success = false, Message = "Game has already started" };
+        if (room.hasStarted()) return new JoinRoomResult { Success = false, Message = "Game has already started", State = GameState.inProgress };
 
-        if (room.hasPlayer(username))
-            return new JoinRoomResult { Success = false, Message = "Username is already taken" };
+        if (room.hasPlayer(username)) return new JoinRoomResult { Success = false, Message = "Username is already taken", State = room.State };
         
-
-        return new JoinRoomResult { Success = true };
+        return new JoinRoomResult { Success = true, State = room.State };
     }
     
 }

--- a/KNOTS/Services/GameRoomService.cs
+++ b/KNOTS/Services/GameRoomService.cs
@@ -43,25 +43,14 @@ namespace KNOTS.Services
         private string GenerateRoomCode()
         {
             string code;
-            do
-            {
-                code = _random.Next(1000, 9999).ToString();
-            } while (_rooms.ContainsKey(code));
-            
-            return code;
+            do { code = _random.Next(1000, 9999).ToString(); } while (_rooms.ContainsKey(code)); return code;
         }
-
         // Prideda žaidėją prie sistemos
-        public void AddPlayer(string connectionId, string username)
-        {
-            _connectionToUsername[connectionId] = username;
-        }
+        public void AddPlayer(string connectionId, string username) { _connectionToUsername[connectionId] = username; }
 
         // Sukuria naują kambarį
-        public string CreateRoom(string hostConnectionId, string hostUsername)
-        {
+        public string CreateRoom(string hostConnectionId, string hostUsername) {
             var roomCode = GenerateRoomCode();
-            
             var room = new GameRoom
             {
                 RoomCode = roomCode,
@@ -84,21 +73,11 @@ namespace KNOTS.Services
         }
 
         // Prisijungia prie kambario
-        public JoinRoomResult JoinRoom(string roomCode, string connectionId, string username)
-        {
-            if (!_rooms.TryGetValue(roomCode, out var room))
-            {
-                return new JoinRoomResult 
-                { 
-                    Success = false, 
-                    Message = "Room not found" 
-                };
-            }
+        public JoinRoomResult JoinRoom(string roomCode, string connectionId, string username) {
+            if (!_rooms.TryGetValue(roomCode, out var room)) return new JoinRoomResult { Success = false, Message = "Room not found" };
 
             var result = new GameRoom().CanJoin(username);
-            if (!result.Success)
-                return result;
-            
+            if (!result.Success) return result;
             
             var player = new GamePlayer
             {
@@ -119,61 +98,43 @@ namespace KNOTS.Services
         }
 
         // Gauna kambario informaciją
-        public GameRoom? GetRoomInfo(string roomCode)
-        {
+        public GameRoom? GetRoomInfo(string roomCode) {
             _rooms.TryGetValue(roomCode, out var room);
             return room;
         }
 
         // Gauna žaidėjo vardą pagal ConnectionId
-        public string GetPlayerUsername(string connectionId)
-        {
+        public string GetPlayerUsername(string connectionId) {
             _connectionToUsername.TryGetValue(connectionId, out var username);
             return username ?? "";
         }
 
         // Pašalina žaidėją iš sistemos
-        public DisconnectedPlayerInfo RemovePlayer(string connectionId)
-        {
+        public DisconnectedPlayerInfo RemovePlayer(string connectionId) {
             var result = new DisconnectedPlayerInfo();
             
             _connectionToUsername.TryGetValue(connectionId, out var username);
             result.Username = username ?? "";
 
-            if (_playerToRoom.TryRemove(connectionId, out var roomCode))
-            {
+            if (_playerToRoom.TryRemove(connectionId, out var roomCode)) {
                 result.RoomCode = roomCode;
                 
-                if (_rooms.TryGetValue(roomCode, out var room))
-                {
+                if (_rooms.TryGetValue(roomCode, out var room)) { 
                     room.Players.RemoveAll(p => p.ConnectionId == connectionId);
-                    
                     // Jei kambarys tuščias, pašalinam jį
-                    if (room.Players.Count == 0)
-                    {
-                        _rooms.TryRemove(roomCode, out _);
-                    }
+                    if (room.Players.Count == 0) { _rooms.TryRemove(roomCode, out _); }
                     // Jei išėjo host'as, paskiriame naują
-                    else if (room.Host == username && room.Players.Count > 0)
-                    {
-                        room.Host = room.Players.First().Username;
-                    }
+                    else if (room.Host == username && room.Players.Count > 0) { room.Host = room.Players.First().Username; }
                 }
             }
-
             _connectionToUsername.TryRemove(connectionId, out _);
             return result;
         }
 
         // Gauna visų kambarių sąrašą (debug tikslams)
-        public List<GameRoom> GetAllRooms()
-        {
-            return _rooms.Values.ToList();
-        }
-
+        public List<GameRoom> GetAllRooms() { return _rooms.Values.ToList(); }
         // Gauna kambario kodą pagal žaidėjo ConnectionId
-        public string? GetPlayerRoomCode(string connectionId)
-        {
+        public string? GetPlayerRoomCode(string connectionId) {
             _playerToRoom.TryGetValue(connectionId, out var roomCode);
             return roomCode;
         }

--- a/KNOTS/Services/GameRoomService.cs
+++ b/KNOTS/Services/GameRoomService.cs
@@ -95,34 +95,11 @@ namespace KNOTS.Services
                 };
             }
 
-            if (room.Players.Count >= room.MaxPlayers)
-            {
-                return new JoinRoomResult 
-                { 
-                    Success = false, 
-                    Message = "Room is full" 
-                };
-            }
-
-            if (room.IsGameStarted)
-            {
-                return new JoinRoomResult 
-                { 
-                    Success = false, 
-                    Message = "Game has already started" 
-                };
-            }
-
-            // Tikrina ar žaidėjas jau kambaryje
-            if (room.Players.Any(p => p.Username.Equals(username, StringComparison.OrdinalIgnoreCase)))
-            {
-                return new JoinRoomResult 
-                { 
-                    Success = false, 
-                    Message = "A player with this username is already in game" 
-                };
-            }
-
+            var result = new GameRoom().CanJoin(username);
+            if (!result.Success)
+                return result;
+            
+            
             var player = new GamePlayer
             {
                 ConnectionId = connectionId,

--- a/KNOTS/Services/GameRoomService.cs
+++ b/KNOTS/Services/GameRoomService.cs
@@ -76,7 +76,7 @@ namespace KNOTS.Services
         public JoinRoomResult JoinRoom(string roomCode, string connectionId, string username) {
             if (!_rooms.TryGetValue(roomCode, out var room)) return new JoinRoomResult { Success = false, Message = "Room not found" };
 
-            var result = new GameRoom().CanJoin(username);
+            var result = room.CanJoin(username);
             if (!result.Success) return result;
             
             var player = new GamePlayer

--- a/KNOTS/Services/GameRoomService.cs
+++ b/KNOTS/Services/GameRoomService.cs
@@ -2,13 +2,20 @@
 
 namespace KNOTS.Services
 {
+    public enum gameState
+    {
+        waitingForPlayers,
+        inProgress,
+        finished
+    }
     public class GameRoom
     {
         public string RoomCode { get; set; } = string.Empty;
         public string Host { get; set; } = string.Empty;
         public List<GamePlayer> Players { get; set; } = new();
         public DateTime CreatedAt { get; set; } = DateTime.Now;
-        public bool IsGameStarted { get; set; } = false;
+        //public bool IsGameStarted { get; set; } = false;
+        public gameState State { get; set; } = gameState.waitingForPlayers;
         public int MaxPlayers { get; set; } = 4;
     }
 

--- a/KNOTS/Services/GameRoomService.cs
+++ b/KNOTS/Services/GameRoomService.cs
@@ -2,7 +2,7 @@
 
 namespace KNOTS.Services
 {
-    public enum gameState
+    public enum GameState
     {
         waitingForPlayers,
         inProgress,
@@ -15,7 +15,7 @@ namespace KNOTS.Services
         public List<GamePlayer> Players { get; set; } = new();
         public DateTime CreatedAt { get; set; } = DateTime.Now;
         //public bool IsGameStarted { get; set; } = false;
-        public gameState State { get; set; } = gameState.waitingForPlayers;
+        public GameState State { get; set; } = GameState.waitingForPlayers;
         public int MaxPlayers { get; set; } = 4;
     }
 
@@ -31,6 +31,7 @@ namespace KNOTS.Services
     {
         public bool Success { get; set; }
         public string Message { get; set; } = string.Empty;
+        public GameState State { get; set; }
     }
 
     public class DisconnectedPlayerInfo
@@ -81,7 +82,7 @@ namespace KNOTS.Services
 
         // Prisijungia prie kambario
         public JoinRoomResult JoinRoom(string roomCode, string connectionId, string username) {
-            if (!_rooms.TryGetValue(roomCode, out var room)) return new JoinRoomResult { Success = false, Message = "Room not found" };
+            if (!_rooms.TryGetValue(roomCode, out var room)) return new JoinRoomResult { Success = false, Message = "Room not found", State = GameState.finished };
 
             var result = room.CanJoin(username);
             if (!result.Success) return result;
@@ -96,11 +97,14 @@ namespace KNOTS.Services
             room.Players.Add(player);
             _playerToRoom[connectionId] = roomCode;
             _connectionToUsername[connectionId] = username;
+            
+            if (room.Players.Count >= room.MaxPlayers) { room.State = GameState.inProgress; }
 
             return new JoinRoomResult 
             { 
                 Success = true, 
-                Message = "Successfully connected to a room!" 
+                Message = "Successfully connected to a room!",
+                State = room.State
             };
         }
 


### PR DESCRIPTION
Pridetas elementarus extention usage, skirtas pratesti prisijungimo i kambari logika - is gameroomservise isimtas zaideju skaiciaus, kambario pilnumo, vardo patikrinimo kodas ir perkelta i kita gameroomeks klase, kuri yra kaip extention pirmai. Del to galim pridet naujus metodus jau esamam duomenu tipui. Taip pat pridetas enum caseas, kuris is esmes yra zaidimo stadijom valdyt. Kadangi pilnai viso pas mus nera, sita butinai reikes plesti, kad ir pavyzdziui pagal atitinkama zaidimo stadija leisti prisijungti i zaidima ar ne.